### PR TITLE
Revert "Merge PR: read typeinfo with read lock (#4)"

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -478,27 +478,25 @@ func (cdc *Codec) getTypeInfo_wlock(rt reflect.Type) (info *TypeInfo, err error)
 	// We do not use defer cdc.mtx.Unlock() here due to performance overhead of
 	// defer in go1.11 (and prior versions). Ensure new code paths unlock the
 	// mutex.
+	cdc.mtx.Lock() // requires wlock because we might set.
 
 	// Dereference pointer type.
 	for rt.Kind() == reflect.Ptr {
 		rt = rt.Elem()
 	}
 
-	cdc.mtx.RLock() // read with read lock
 	info, ok := cdc.typeInfos[rt]
-	cdc.mtx.RUnlock()
-
 	if !ok {
 		if rt.Kind() == reflect.Interface {
 			err = fmt.Errorf("Unregistered interface %v", rt)
+			cdc.mtx.Unlock()
 			return
 		}
-		cdc.mtx.Lock()
+
 		info = cdc.newTypeInfoUnregistered(rt)
 		cdc.setTypeInfo_nolock(info)
-		cdc.mtx.Unlock()
 	}
-
+	cdc.mtx.Unlock()
 	return info, nil
 }
 


### PR DESCRIPTION
This reverts commit 66849e774e7116e5599856bdb0028d0cbd312bd1.